### PR TITLE
Fix user base exposure 

### DIFF
--- a/src/Gamification.php
+++ b/src/Gamification.php
@@ -80,6 +80,16 @@ class Gamification
     {
         $blockedUsers = explode(', ', $this->settings->get('reflar.gamification.blockedUsers'));
 
+        $maximumUserExposed = $this->settings->get('reflar.gamification.blockedUsers', 10));
+
+        if ($limit > $maximumUserExposed) {
+            $limit = $maximumUserExposed;
+        }
+
+        if ($offset >= $maximumUserExposed) {
+            return [];
+        }
+
         $query = User::query()
             ->whereNotIn('username', $blockedUsers)
             ->orderBy('votes', 'desc')

--- a/src/Gamification.php
+++ b/src/Gamification.php
@@ -20,6 +20,11 @@ use Flarum\Settings\SettingsRepositoryInterface;
 class Gamification
 {
     /**
+     * Sets the maximum number of user exposed through the ranking api.
+     */
+    const MAXIMUM_USER_EXPOSED = 25;
+
+    /**
      * @var PostRepository
      */
     protected $posts;
@@ -80,18 +85,16 @@ class Gamification
     {
         $blockedUsers = explode(', ', $this->settings->get('reflar.gamification.blockedUsers'));
 
-        $maximumUserExposed = $this->settings->get('reflar.gamification.maximumUserExposed', 25);
-
-        if ($limit > $maximumUserExposed) {
-            $limit = $maximumUserExposed;
+        if ($limit > self::MAXIMUM_USER_EXPOSED) {
+            $limit = self::MAXIMUM_USER_EXPOSED;
         }
 
-        if ($offset >= $maximumUserExposed) {
+        if ($offset >= self::MAXIMUM_USER_EXPOSED) {
             return [];
         }
 
-        if (($limit + $offset) > $maximumUserExposed) {
-            $limit = $limit + $offset - $maximumUserExposed;
+        if (($limit + $offset) > self::MAXIMUM_USER_EXPOSED) {
+            $limit = $limit + $offset - self::MAXIMUM_USER_EXPOSED;
         }
 
         $query = User::query()

--- a/src/Gamification.php
+++ b/src/Gamification.php
@@ -80,7 +80,7 @@ class Gamification
     {
         $blockedUsers = explode(', ', $this->settings->get('reflar.gamification.blockedUsers'));
 
-        $maximumUserExposed = $this->settings->get('reflar.gamification.blockedUsers', 10));
+        $maximumUserExposed = $this->settings->get('reflar.gamification.maximumUserExposed', 25);
 
         if ($limit > $maximumUserExposed) {
             $limit = $maximumUserExposed;
@@ -88,6 +88,10 @@ class Gamification
 
         if ($offset >= $maximumUserExposed) {
             return [];
+        }
+
+        if (($limit + $offset) > $maximumUserExposed) {
+            $limit = $limit + $offset - $maximumUserExposed;
         }
 
         $query = User::query()


### PR DESCRIPTION
I implemented only the backend side by reading a `reflar.gamification.maximumUserExposed` setting from the database. It defaults to 25 (might be not that much tho).

The admin panel can be edited to support the new setting so that we can close the circle and a new version might be released.